### PR TITLE
DEP: bump minimal requirement on numpy (for Python 3.11 support)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "numpy>=1.22.0",
+    "numpy>=1.24.0",
 ]
 
 [project.readme]

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ typecheck = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "numpy", specifier = ">=1.22.0" }]
+requires-dist = [{ name = "numpy", specifier = ">=1.24.0" }]
 
 [package.metadata.requires-dev]
 covcheck = [


### PR DESCRIPTION
follow up to #83